### PR TITLE
Disables linter action

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -8,9 +8,9 @@ name: Lint Code Base
 
 on:
   push:
-    branches: [ main ]
+#    branches: [ main ]
   pull_request:
-    branches: [ main ]
+#    branches: [ main ]
 jobs:
   run-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #31 

Disables the linter action as it does not comply with our (the group) agreed upon standard.

Customizing the linter is an option; however, due to limited time we chose to prioritize implementing the functionality first rather than customizing the linter.