### PR TITLE
Refactored PreliminaryUnlockingMatrix #75

### DIFF
--- a/src/main/java/com/group10/decide/Decider.java
+++ b/src/main/java/com/group10/decide/Decider.java
@@ -1,27 +1,34 @@
 package com.group10.decide;
 
 /**
- * Decider class which can be called to sequentially computes the CMV, PUM and FUV.
+ * Decider class which can be called to sequentially computes the CMV, PUM and
+ * FUV.
+ * 
  * @author Bror Sebastian Sjovald
  */
 public class Decider {
     ParameterManager pm;
 
     /**
-     * Constructor for the Decider class. Takes in everything needed to calculate CMV, PUM and FUV.
-     * @param pm    Parameters used by the "Decide" program
+     * Constructor for the Decider class. Takes in everything needed to calculate
+     * CMV, PUM and FUV.
+     * 
+     * @param pm Parameters used by the "Decide" program
      */
     public Decider(ParameterManager pm) {
         this.pm = pm;
     }
 
     /**
-     * Calculates the CMV, PUM and FUV sequentially to decide whether to LAUNCH or not
+     * Calculates the CMV, PUM and FUV sequentially to decide whether to LAUNCH or
+     * not
+     * 
      * @return A boolean signal that indicates the LAUNCH decision
      */
     public boolean decide() {
         ConditionsMetVector cmv = new ConditionsMetVector(15, pm);
-        PreliminaryUnlockingMatrix pum = new PreliminaryUnlockingMatrix(pm, 15, 15, cmv.getConditionsMetVector());
+        PreliminaryUnlockingMatrix pum = new PreliminaryUnlockingMatrix(pm.getLogicalConnectorMatrix(),
+                cmv.getConditionsMetVector());
         FinalUnlockingVector fuv = new FinalUnlockingVector(pm, 15, pum.getPUM());
         return fuv.hasAllTrueValues();
     }

--- a/src/main/java/com/group10/decide/PreliminaryUnlockingMatrix.java
+++ b/src/main/java/com/group10/decide/PreliminaryUnlockingMatrix.java
@@ -1,55 +1,36 @@
 package com.group10.decide;
 
-
 /**
  * Represents and calculates the Preliminary Unlocking Matrix
  *
  * @author Bror Sebastian Sjövald
  */
 public class PreliminaryUnlockingMatrix {
-    private Matrix<Connector> lcm;
-    private int rows, cols;
-    private Vector<Boolean> cmv;
+    private final int N = 15;
     private Matrix<Boolean> pum;
 
     /**
-     * Constructor for PreliminaryUnlockingMatrix class with option to explicitly set rows and cols
+     * Constructor for PreliminaryUnlockingMatrix class that takes in LCM and CMV
      *
-     * @param pm                    ParameterManager containing LCM
-     * @param rows                  Rows of PUM
-     * @param cols                  Cols of PUM
-     * @param conditionsMetVector   CMV with which LICs are fulfilled
-     */
-    public PreliminaryUnlockingMatrix(ParameterManager pm, int rows, int cols, Vector<Boolean> conditionsMetVector) {
-        this.lcm = pm.getLogicalConnectorMatrix();
-        this.rows = rows;
-        this.cols = cols;
-        this.cmv = conditionsMetVector;
-        this.pum = new Matrix<>(rows, cols);
-        this.calculatePUM();
-    }
-
-    /**
-     * Constructor for PreliminaryUnlockingMatrix class with option to give LCM without a ParameterManager
-     *
-     * @param logicalConnectorMatrix    A 15x15 matrix indicating which boolean operator should be used
-     * @param conditionsMetVector       CMV with which LICs are fulfilled
+     * @param logicalConnectorMatrix A 15x15 matrix indicating which boolean
+     *                               operator should be used
+     * @param conditionsMetVector    CMV of length 15 with which LICs are fulfilled
      */
     public PreliminaryUnlockingMatrix(Matrix<Connector> logicalConnectorMatrix, Vector<Boolean> conditionsMetVector) {
-        this.lcm = logicalConnectorMatrix;
-        this.cmv = conditionsMetVector;
-        this.rows = 15;
-        this.cols = 15;
         this.pum = new Matrix<>(15, 15);
-        this.calculatePUM();
+        this.calculatePUM(logicalConnectorMatrix, conditionsMetVector);
     }
 
     /**
      * Calculates the Preliminary Unlocking Matrix with values set in the object
+     * 
+     * @param lcm A 15x15 matrix indicating which boolean
+     *            operator should be used
+     * @param cmv CMV of length 15 with which LICs are fulfilled
      */
-    public void calculatePUM() {
+    public void calculatePUM(Matrix<Connector> lcm, Vector<Boolean> cmv) {
         Boolean pumVal;
-        for (int i = 0; i < rows; i++) {
+        for (int i = 0; i < N; i++) {
             for (int j = 0; j < i + 1; j++) {
                 switch (lcm.getValue(i, j)) {
                     case NOTUSED:
@@ -70,7 +51,6 @@ public class PreliminaryUnlockingMatrix {
             }
         }
     }
-
 
     /**
      * Gets the PreliminaryUnlockingMatrix


### PR DESCRIPTION
This PR is for issue #75 and refactors the PreliminaryUnlockingMatrix class.

- Remove fields for rows, cols, lcm, cmv
- Remove constructor that take in unnecessary info
- Add parameters to `calculatePUM()` in order to take in LCM and CMV

Closes #75
